### PR TITLE
Switch to LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ simplelog = "0.7.1"
 [dependencies.prometheus]
 version = "0.7"
 default-features = false
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Before:

```
$ cargo bloat --release --crates
   Compiling psi_exporter v0.1.0 (/state/home/ivan/psi_exporter)
    Finished release [optimized] target(s) in 2.06s
    Analyzing target/release/psi_exporter

 File  .text     Size Crate
 8.6%  33.9% 349.0KiB clap
 8.2%  32.2% 331.4KiB std
 3.9%  15.4% 158.3KiB tiny_http
 2.0%   7.9%  81.2KiB prometheus
 0.9%   3.5%  35.7KiB [Unknown]
 0.5%   2.1%  22.1KiB walkdir
 0.4%   1.5%  15.9KiB psi_exporter
 0.3%   1.3%  13.4KiB psi
 0.3%   1.1%  11.0KiB chrono
 0.1%   0.3%   3.3KiB ansi_term
 0.1%   0.2%   2.4KiB strsim
 0.0%   0.2%   1.8KiB textwrap
 0.0%   0.1%     852B chunked_transfer
 0.0%   0.1%     775B same_file
 0.0%   0.1%     687B idna
 0.0%   0.0%     462B ascii
 0.0%   0.0%     335B time
 0.0%   0.0%     279B log
 0.0%   0.0%      28B atty
25.4% 100.0%   1.0MiB .text section size, the file size is 4.0MiB
```

After:

```
$ cargo bloat --release --crates
   Compiling psi_exporter v0.1.0 (/state/home/ivan/psi_exporter)
    Finished release [optimized] target(s) in 17.39s
    Analyzing target/release/psi_exporter

 File  .text     Size Crate
13.7%  34.8% 325.7KiB clap
11.3%  28.5% 267.3KiB std
 5.9%  15.1% 141.0KiB tiny_http
 3.1%   7.8%  73.4KiB psi_exporter
 2.2%   5.6%  52.0KiB prometheus
 1.6%   4.0%  37.3KiB [Unknown]
 0.8%   2.0%  18.6KiB walkdir
 0.4%   1.1%  10.6KiB psi
 0.1%   0.4%   3.4KiB ansi_term
 0.1%   0.3%   2.8KiB strsim
 0.1%   0.2%   1.8KiB chrono
 0.1%   0.2%   1.5KiB idna
 0.0%   0.1%     847B chunked_transfer
 0.0%   0.0%     315B ascii
 0.0%   0.0%     180B same_file
 0.0%   0.0%      64B time
 0.0%   0.0%      25B log
39.5% 100.0% 936.8KiB .text section size, the file size is 2.3MiB
```