### PR TITLE
Remove unnecessary use statements and fix typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use prometheus::Encoder;
 
 const MOUNTPOINT: &str = "/sys/fs/cgroup";
-const PRESSIRE_SUFFIX: &str = ".pressure";
+const PRESSURE_SUFFIX: &str = ".pressure";
 
 fn main() {
     let matches = clap::App::new(clap::crate_name!())
@@ -197,7 +197,7 @@ fn get_service_measurements() -> HashMap<String, PsiMeasurements> {
 
         let mut controller = path.file_name().unwrap().to_str().unwrap().to_string();
 
-        controller.truncate(controller.len() - PRESSIRE_SUFFIX.len());
+        controller.truncate(controller.len() - PRESSURE_SUFFIX.len());
 
         let mut file = skip_fail!(fs::OpenOptions::new().read(true).open(path));
         let mut buf = String::with_capacity(256);
@@ -251,7 +251,7 @@ fn is_pressure(entry: &walkdir::DirEntry) -> bool {
     entry
         .file_name()
         .to_str()
-        .map(|s| s.ends_with(PRESSIRE_SUFFIX))
+        .map(|s| s.ends_with(PRESSURE_SUFFIX))
         .unwrap_or(false)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,6 @@ use std::net;
 
 use std::io::Read;
 
-use maplit;
-use prometheus;
-use psi;
-use tiny_http;
-use walkdir;
-
 use prometheus::Encoder;
 
 const MOUNTPOINT: &str = "/sys/fs/cgroup";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections;
+use std::collections::HashMap;
 use std::fs;
 use std::net;
 
@@ -68,7 +68,7 @@ fn main() {
 }
 
 fn registry(
-    service_measurements: &collections::HashMap<String, PsiMeasurements>,
+    service_measurements: &HashMap<String, PsiMeasurements>,
     report_avg: bool,
     report_zeros: bool,
 ) -> prometheus::Registry {
@@ -178,8 +178,8 @@ macro_rules! skip_fail {
     };
 }
 
-fn get_service_measurements() -> collections::HashMap<String, PsiMeasurements> {
-    let mut services: collections::HashMap<_, PsiMeasurements> = collections::HashMap::new();
+fn get_service_measurements() -> HashMap<String, PsiMeasurements> {
+    let mut services: HashMap<_, PsiMeasurements> = HashMap::new();
 
     for entry in walkdir::WalkDir::new(MOUNTPOINT)
         .into_iter()


### PR DESCRIPTION
The compiler gives a warning that there are unnecessary `use` statements with a single path component. See [clippy/single_component_path_imports](https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports).