### PR TITLE
skip over cgroup.pressure file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use prometheus::Encoder;
 
 const MOUNTPOINT: &str = "/sys/fs/cgroup";
 const PRESSURE_SUFFIX: &str = ".pressure";
+const CGROUP_PRESSURE_OPTION_FILE: &str = "cgroup.pressure";
 
 fn main() {
     let matches = clap::App::new(clap::crate_name!())
@@ -251,7 +252,7 @@ fn is_pressure(entry: &walkdir::DirEntry) -> bool {
     entry
         .file_name()
         .to_str()
-        .map(|s| s.ends_with(PRESSURE_SUFFIX))
+        .map(|s| s.ends_with(PRESSURE_SUFFIX) && s != CGROUP_PRESSURE_OPTION_FILE)
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
it only contains a single number, 0 or 1, to indicate whether pressure stall informaiton is turned on or off for the cgroup. The unexpected format causes a panic:

```
thread 'main' panicked at src/main.rs:211:33:
called `Result::unwrap()` on an `Err` value: PsiParseError(UnexpectedTerm("1"))
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: core::result::Result<T,E>::unwrap
             at /builddir/build/BUILD/rustc-1.76.0-src/library/core/src/result.rs:1073:23
   4: psi_exporter::get_service_measurements
             at ./src/main.rs:211:26
   5: psi_exporter::main
             at ./src/main.rs:60:33
   6: core::ops::function::FnOnce::call_once
             at /builddir/build/BUILD/rustc-1.76.0-src/library/core/src/ops/function.rs:250:5
```